### PR TITLE
Add small delay to prevent PHP from consuming too much of the CPU

### DIFF
--- a/src/Gearman/Application.php
+++ b/src/Gearman/Application.php
@@ -318,6 +318,8 @@ class Application implements Serializable
                     $callback($this);
                 }
             }
+
+            usleep(50000);
         }
 
         if (!$this->getKill() && $worker instanceof \GearmanWorker) {


### PR DESCRIPTION
On smaller servers, PHP/Gearman eats up 100% of the CPU and pushes the load above 1 continuously. This small delay reduces it to a more manageable 20-30% and keeps load below 1.