### PR TITLE
Fix: Do not suggest, but require ext-gearman

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,13 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/console": "2.*",
+        "ext-gearman": "*",
+        "psr/log": "~1",
         "react/event-loop": "0.4.*",
-        "psr/log": "~1"
+        "symfony/console": "2.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4"
-    },
-    "suggest": {
-        "ext-gearman": "This library needs Gearman"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR

* [x] requires `ext-gearman`, instead of suggesting it

:information_desk_person: Because it *is* required, isn't it?