### PR TITLE
Fix: Remove unused private property

### DIFF
--- a/src/Worker.php
+++ b/src/Worker.php
@@ -25,11 +25,6 @@ class Worker
     private $logger;
 
     /**
-     * @var array
-     */
-    private $functions = [];
-
-    /**
      * @param Config $config
      * @param null|LoggerInterface $logger
      * @throws ServerConnectionException


### PR DESCRIPTION
This PR

* [x] removes an unused `private` property