### PR TITLE
Fix: Also validate composer.json on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
 
 before_install:
   - composer self-update
+  - composer validate
 
 install:
   # gearman


### PR DESCRIPTION
This PR

* [x] validates `composer.json` on Travis

:information_desk_person: Just to make sure, right?