### PR TITLE
Fix: Use phpunit as installed with Composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ install:
 
 script:
   - gearmand -d
-  - phpunit
+  - vendor/bin/phpunit
 


### PR DESCRIPTION
This PR

* [x] uses `phpunit` on Travis as installed with Composer