### PR TITLE
Fix: Start daemon in before_script section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,9 @@ install:
   ## Composer
   - composer install
 
-script:
+before_script:
   - gearmand -d
+
+script:
   - vendor/bin/phpunit
 


### PR DESCRIPTION
This PR

* [x] starts the Gearman daemon in the `before_script` section